### PR TITLE
Fix backslash before closing quote parsing issue

### DIFF
--- a/main.js
+++ b/main.js
@@ -71,7 +71,7 @@ function parse(text, options) {
         var comment_slash_pos = -1;
         sanitization: for (var l = 0; l < _line.length; l++) {
             switch (_line.charAt(l)) {
-                case '"': if (_line.charAt(l-1) != '\\') odd = !odd; break;
+                case '"': if (_line.charAt(l - 1) !== '\\' || _line.charAt(l - 2) === '\\') odd = !odd; break;
                 case '/': if (!odd) { comment_slash_pos = l; break sanitization; } break;
                 case '{': if (!odd) { _line = _line.slice(0, l) + "\n{\n" + _line.slice(l+1); l+=2; } break;
                 case '}': if (!odd) { _line = _line.slice(0, l) + "\n}\n" + _line.slice(l+1); l+=2; } break;

--- a/main.js
+++ b/main.js
@@ -71,7 +71,7 @@ function parse(text, options) {
         var comment_slash_pos = -1;
         sanitization: for (var l = 0; l < _line.length; l++) {
             switch (_line.charAt(l)) {
-                case '"': if (_line.charAt(l - 1) !== '\\' || _line.charAt(l - 2) === '\\') odd = !odd; break;
+                case '"': if (_line.charAt(l-1) !== '\\' || _line.charAt(l-2) === '\\') odd = !odd; break;
                 case '/': if (!odd) { comment_slash_pos = l; break sanitization; } break;
                 case '{': if (!odd) { _line = _line.slice(0, l) + "\n{\n" + _line.slice(l+1); l+=2; } break;
                 case '}': if (!odd) { _line = _line.slice(0, l) + "\n}\n" + _line.slice(l+1); l+=2; } break;


### PR DESCRIPTION
Fixes edge case with value ending with a backslash, even escaped:
```
"UserLocalConfigStore"
{
	"friends"
	{
		"9734658" "Grocel"
		"5318652" "/Hexalitos\\" <-- this one
		"19358028" "put in"
	}
}
```
```
SyntaxError: VDF.parse: invalid syntax on line 8:
"
```

As an additional bonus, adds strict comparison in this line where it's appropriate